### PR TITLE
Rename ApacheUniqueIdProvider to ServerRequestIdProvider

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,8 @@ the_red_dot_monolog_extra:
 The bundle comes with 2 providers:
 
 * UniqidProvider (default): use `uniqid`
-* ApacheUniqueIdProvider: get from environment, need [*mod_unique_id*](https://httpd.apache.org/docs/2.4/mod/mod_unique_id.html) of Apache
+* ServerRequestIdProvider: get from `$_SERVER`
+  * you need to pass the name of a field of `$_SERVER`, example for [*mod_unique_id*](https://httpd.apache.org/docs/2.4/mod/mod_unique_id.html) of Apache: `UNIQUE_ID`.
 
 You can create your own provider by creating a service that implements *TheRedDot\MonologExtraBundle\Provider\RequestId\RequestIdProviderInterface*.
 

--- a/spec/Provider/RequestId/ServerRequestIdProviderSpec.php
+++ b/spec/Provider/RequestId/ServerRequestIdProviderSpec.php
@@ -1,16 +1,21 @@
 <?php
 
-namespace spec\TheRedDot\MonologExtraBundle\Provider\Uid;
+namespace spec\TheRedDot\MonologExtraBundle\Provider\RequestId;
 
-use TheRedDot\MonologExtraBundle\Provider\RequestId\ApacheUniqueIdProvider;
+use TheRedDot\MonologExtraBundle\Provider\RequestId\ServerRequestIdProvider;
 use TheRedDot\MonologExtraBundle\Provider\RequestId\RequestIdProviderInterface;
 use PhpSpec\ObjectBehavior;
 
-class ApacheUniqueIdProviderSpec extends ObjectBehavior
+class ServerRequestIdProviderSpec extends ObjectBehavior
 {
+    public function let()
+    {
+        $this->beConstructedWith('UNIQUE_ID');
+    }
+
     public function it_is_initializable()
     {
-        $this->shouldHaveType(ApacheUniqueIdProvider::class);
+        $this->shouldHaveType(ServerRequestIdProvider::class);
     }
 
     public function it_implements_request_id_provider_interface()
@@ -31,7 +36,7 @@ class ApacheUniqueIdProviderSpec extends ObjectBehavior
 
     public function it_returns_request_id_from_server_data()
     {
-        $this->beConstructedWith(['UNIQUE_ID' => 'sqdfjhqsodukfhqsdui']);
+        $this->beConstructedWith('UNIQUE_ID', ['UNIQUE_ID' => 'sqdfjhqsodukfhqsdui']);
         $this->getRequestId()->shouldReturn('sqdfjhqsodukfhqsdui');
     }
 }

--- a/spec/Provider/RequestId/UniqidProviderSpec.php
+++ b/spec/Provider/RequestId/UniqidProviderSpec.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace spec\TheRedDot\MonologExtraBundle\Provider\Uid;
+namespace spec\TheRedDot\MonologExtraBundle\Provider\RequestId;
 
 use TheRedDot\MonologExtraBundle\Provider\RequestId\RequestIdProviderInterface;
 use TheRedDot\MonologExtraBundle\Provider\RequestId\UniqidProvider;

--- a/src/Provider/RequestId/ServerRequestIdProvider.php
+++ b/src/Provider/RequestId/ServerRequestIdProvider.php
@@ -2,14 +2,14 @@
 
 namespace TheRedDot\MonologExtraBundle\Provider\RequestId;
 
-final class ApacheUniqueIdProvider implements RequestIdProviderInterface
+final class ServerRequestIdProvider implements RequestIdProviderInterface
 {
     /**
      * @var string
      */
     private $requestId;
 
-    public function __construct(array $serverData = null)
+    public function __construct(string $serverField, array $serverData = null)
     {
         $requestId = uniqid();
 
@@ -17,8 +17,8 @@ final class ApacheUniqueIdProvider implements RequestIdProviderInterface
             $serverData = &$_SERVER;
         }
 
-        if (isset($serverData['UNIQUE_ID'])) {
-            $requestId = $serverData['UNIQUE_ID'];
+        if (isset($serverData[$serverField])) {
+            $requestId = $serverData[$serverField];
         }
 
         $this->requestId = $requestId;

--- a/src/Provider/RequestId/ServerRequestIdProvider.php
+++ b/src/Provider/RequestId/ServerRequestIdProvider.php
@@ -11,17 +11,16 @@ final class ServerRequestIdProvider implements RequestIdProviderInterface
 
     public function __construct(string $serverField, array $serverData = null)
     {
-        $requestId = uniqid();
-
         if (!is_array($serverData)) {
             $serverData = &$_SERVER;
         }
 
+        $requestId = null;
         if (isset($serverData[$serverField])) {
             $requestId = $serverData[$serverField];
         }
 
-        $this->requestId = $requestId;
+        $this->requestId = $requestId ?? uniqid();
     }
 
     public function getRequestId(): string


### PR DESCRIPTION
And allow to get the request_id from any field of `$_SERVER`

#1 