### PR TITLE
Remove useless conditional statement in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ cache:
 
 before_install:
     - composer self-update
-    - if [ "$DEPENDENCIES" = "beta" ]; then composer config minimum-stability beta; fi;
     - if [ "$SYMFONY_VERSION" != "" ]; then composer require --no-update symfony/security:$SYMFONY_VERSION symfony/config:$SYMFONY_VERSION symfony/http-foundation:$SYMFONY_VERSION symfony/dependency-injection:$SYMFONY_VERSION symfony/http-kernel:$SYMFONY_VERSION; fi
 
 install: composer update --prefer-dist --no-interaction $COMPOSER_FLAGS


### PR DESCRIPTION
There is no use of `$DEPENDENCIES` env var in our travis CI config. 