### PR TITLE
Use vendor/bin instead of bin for vendor binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
 vendor
 composer.lock
-build
-bin
 .php_cs.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_install:
 install: composer update --prefer-dist --no-interaction $COMPOSER_FLAGS
 
 script:
-    - bin/phpspec run -fpretty --verbose
+    - vendor/bin/phpspec run -fpretty --verbose
 
 jobs:
     include:
@@ -37,9 +37,9 @@ jobs:
           php: 7.3
           env: SYMFONY_VERSION=""
           script:
-              - ./bin/php-cs-fixer fix --dry-run -v --show-progress=dots --diff-format=udiff
+              - vendor/bin/php-cs-fixer fix --dry-run -v --show-progress=dots --diff-format=udiff
         - stage: "Static Analysis"
           php: 7.3
           env: SYMFONY_VERSION=""
           script:
-              - ./bin/phpstan analyse
+              - vendor/bin/phpstan analyse

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,6 @@
         "phpstan/phpstan": "^0.11.7"
     },
     "config": {
-        "bin-dir": "bin",
         "sort-packages": true
     },
     "extra": {


### PR DESCRIPTION
Use a `bin` dir at the root of the project is not very common. 
Let's back to standard.